### PR TITLE
fix typo in docs: spacial -> special

### DIFF
--- a/docs/tutorials/introduction.ipynb
+++ b/docs/tutorials/introduction.ipynb
@@ -428,7 +428,7 @@
    "source": [
     "## Creating and Contributing Augmenters\n",
     "\n",
-    "After using augmenty you might want to create and contribute an augmenter. Most augmenters can be created based on already existing augmenters. For instance the augmenter `per_replace_v1`, which replaces names in a text is a spacial case of the augmenter `ents_replace_v1` with better handling of first and last names. If you want to create an augmenter from scratch following spaCy's [guide](https://spacy.io/usage/training#data-augmentation-custom) on creating custom augmenters is a good start. You can always use augmenters from augmenty as inspiration as well. If you find yourself in troubles feel free to ask in the [augmenty forums](missing). \n",
+    "After using augmenty you might want to create and contribute an augmenter. Most augmenters can be created based on already existing augmenters. For instance the augmenter `per_replace_v1`, which replaces names in a text is a special case of the augmenter `ents_replace_v1` with better handling of first and last names. If you want to create an augmenter from scratch following spaCy's [guide](https://spacy.io/usage/training#data-augmentation-custom) on creating custom augmenters is a good start. You can always use augmenters from augmenty as inspiration as well. If you find yourself in troubles feel free to ask in the [augmenty forums](missing). \n",
     "\n",
     "When you are satisfied with your augmenter feel free submit a [pull request](https://github.com/KennethEnevoldsen/augmenty/pulls) to add the augmenter to augmenty."
    ]


### PR DESCRIPTION
Hi, I noticed this typo while reading the docs - thought I would open a quick PR to fix it.