### PR TITLE
Fix docs GitHub link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ html_show_sourcelink = True
 
 html_context = {
     "display_github": True,  # Add 'Edit on Github' link instead of 'View page source'
-    "github_user": "KennethEnevoldsen",
+    "github_user": github_user,
     "github_repo": project,
     "github_version": "main",
     "conf_py_path": "/docs/",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ from augmenty.about import __version__
 
 project = "augmenty"
 author = "Kenneth Enevoldsen"
-github_user = "KenethEnevoldsen"
+github_user = "KennethEnevoldsen"
 repo_url = f"https://github.com/{github_user}/{project}"
 
 


### PR DESCRIPTION
When I noticed the typo in #210 , I clicked the GitHub icon at the bottom of the docs, and got a 404. I dug into this and it appears to be a typo in the `github_user` variable in `docs/conf.py`.

I also noticed the GitHub user was also stored elsewhere in the same file, so I thought it would be nice to share the same variable (I can undo this commit if you don't like it though). 

(Although to be honest, I'm not sure if  `"display_github"` and the related parts of `html_context` actually do anything at the moment, I think maybe they're ReadTheDocs specific?)

I've built the docs locally and checked that the new link is fixed.